### PR TITLE
Disallow creating new testrun if run_id exists (#23)

### DIFF
--- a/pytest_pytestrail/_config.py
+++ b/pytest_pytestrail/_config.py
@@ -62,6 +62,14 @@ class Config:
         )
         self.work()
 
+    def is_test_run_available(self):
+        """
+        Validates that a test run exist and is not closed
+        :return: True if the test run exists and is OPEN
+        """
+        if self.test_run:
+            return True if not self.api.runs.get_run(self.test_run)["is_completed"] else False
+
     def work(self) -> None:
         if self.project_id:
             val = {
@@ -78,7 +86,10 @@ class Config:
                 val["include_all"] = False
             else:
                 val["include_all"] = True
-            response = self.api.runs.add_run(**val)
+            if self.is_test_run_available():
+                response = self.api.runs.get_run(self.test_run)
+            else:
+                response = self.api.runs.add_run(**val)
             self.test_run = response["id"]
         elif not self.test_run:
             raise pytest.UsageError("No args project_id or test_run")


### PR DESCRIPTION
This commit aims to fix issue #23 by pre-checking whether or not the supplied test run id exists. If it doesn't exist, an error is raised that the test run id doesn't exist.